### PR TITLE
Add nice liveness graph output to the Polonius CLI wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "polonius"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -421,6 +421,7 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "polonius-engine 0.8.0",
  "polonius-parser 0.3.0",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polonius"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["The Rust Project Developers", "Polonius Developers"]
 description = "Core definition for the Rust borrow checker"
 license = "Apache-2.0/MIT"
@@ -22,5 +22,6 @@ structopt = "0.2.8"
 clap = "2.31.2"
 polonius-engine = {version = "0.8.0", path = "polonius-engine" }
 log = "0.4"
+petgraph = "0.4.13"
 
 [workspace]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,10 @@
 # polonius
 
+## v0.5.0
+
+Add a CLI option `--dump-liveness-graph` to dump a Graphviz file with a
+(reduced) liveness-related graph for debugging.
+
 ## v0.4.0
 
 - adopt latest polonius-engine

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,6 +8,9 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 use structopt::StructOpt;
 
+type PoloniusFacts = AllFacts<Region, Loan, Point, Variable>;
+type PoloniusOutput = Output<Region, Loan, Point, Variable>;
+
 #[derive(StructOpt, Debug)]
 #[structopt(name = "borrow-check")]
 pub struct Opt {
@@ -41,6 +44,11 @@ pub struct Opt {
     output_directory: Option<String>,
     #[structopt(raw(required = "true"))]
     fact_dirs: Vec<String>,
+    #[structopt(
+        long = "dump-liveness-graph",
+        help = "Generate a graphviz file to visualize the liveness information"
+    )]
+    liveness_graph_file: Option<String>,
 }
 
 macro_rules! attempt {
@@ -55,22 +63,19 @@ pub fn main(opt: Opt) -> Result<(), Error> {
         .as_ref()
         .map(|x| Path::new(x).to_owned());
     let graphviz_file = opt.graphviz_file.as_ref().map(|x| Path::new(x).to_owned());
+    let liveness_graph_file = opt
+        .liveness_graph_file
+        .as_ref()
+        .map(|x| Path::new(x).to_owned());
     for facts_dir in &opt.fact_dirs {
         let tables = &mut intern::InternerTables::new();
 
-        let result: Result<
-            (
-                Duration,
-                AllFacts<Region, Loan, Point, Variable>,
-                Output<Region, Loan, Point, Variable>,
-            ),
-            Error,
-        > = attempt! {
+        let result: Result<(Duration, PoloniusFacts, PoloniusOutput), Error> = attempt! {
             let verbose = opt.verbose;
             let all_facts =
                 tab_delim::load_tab_delimited_facts(tables, &Path::new(&facts_dir))?;
             let algorithm = opt.algorithm;
-            let graphviz_output = graphviz_file.is_some();
+            let graphviz_output = graphviz_file.is_some() || liveness_graph_file.is_some();
             let (duration, output) =
                 timed(|| Output::compute(&all_facts, algorithm, verbose || graphviz_output));
             (duration, all_facts, output)
@@ -92,6 +97,10 @@ pub fn main(opt: Opt) -> Result<(), Error> {
                 if let Some(ref graphviz_file) = graphviz_file {
                     dump::graphviz(&output, &all_facts, graphviz_file, tables)
                         .expect("Failed to write GraphViz");
+                }
+                if let Some(ref liveness_graph_file) = liveness_graph_file {
+                    dump::liveness_graph(&output, &all_facts, liveness_graph_file, tables)
+                        .expect("Failed to write liveness graph");
                 }
             }
 

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -1,10 +1,13 @@
 use crate::facts::*;
 use crate::intern::InternerTables;
 use crate::intern::*;
+use log::info;
+use petgraph::stable_graph::StableGraph;
+use petgraph::visit::{Dfs, EdgeRef, IntoEdgeReferences, IntoNodeReferences, NodeIndexable};
+use petgraph::{Incoming, Outgoing};
 use polonius_engine::{Atom as PoloniusEngineAtom, Output};
 use rustc_hash::FxHashMap;
-use std::collections::HashMap;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs::File;
 use std::hash::Hash;
 use std::io::{self, Write};
@@ -556,4 +559,260 @@ fn escape_for_graphviz(s: &str) -> String {
         .replace(r")", r"\)")
         .replace("\n", r"\n")
         .to_string()
+}
+
+fn edge_live_vars(source: &Liveness, target: &Liveness) -> HashSet<Variable> {
+    let edge_use_live_vars = source
+        .use_live_vars
+        .intersection(&target.use_live_vars)
+        .cloned()
+        .collect::<HashSet<_>>();
+
+    let edge_drop_live_vars = source
+        .drop_live_vars
+        .intersection(&target.drop_live_vars)
+        .cloned()
+        .collect::<HashSet<_>>();
+
+    edge_use_live_vars
+        .union(&edge_drop_live_vars)
+        .cloned()
+        .collect()
+}
+
+#[derive(Debug)]
+struct Liveness {
+    use_live_vars: HashSet<Variable>,
+    drop_live_vars: HashSet<Variable>,
+    cfg_points: Vec<Point>,
+    point_facts: Vec<(String, Variable, Point)>,
+}
+
+impl Liveness {
+    fn extend(&mut self, other: Liveness) {
+        self.use_live_vars.extend(other.use_live_vars);
+        self.drop_live_vars.extend(other.drop_live_vars);
+        self.cfg_points.extend(other.cfg_points);
+        self.point_facts.extend(other.point_facts);
+    }
+
+    fn from_polonius_data(
+        output: &Output<Region, Loan, Point, Variable>,
+        all_facts: &AllFacts,
+        point: Point,
+    ) -> Self {
+        let mut point_facts = Vec::default();
+
+        point_facts.extend(
+            all_facts
+                .var_defined
+                .iter()
+                .filter(|&(_v, p)| *p == point)
+                .map(|&(v, p)| ("☠".to_string(), v, p)),
+        );
+
+        point_facts.extend(
+            all_facts
+                .var_drop_used
+                .iter()
+                .filter(|&(_v, p)| *p == point)
+                .map(|&(v, p)| ("💧".to_string(), v, p)),
+        );
+
+        point_facts.extend(
+            all_facts
+                .var_used
+                .iter()
+                .filter(|&(_v, p)| *p == point)
+                .map(|&(v, p)| ("🔧".to_string(), v, p)),
+        );
+
+        Self {
+            point_facts,
+            use_live_vars: output
+                .var_live_at
+                .get(&point)
+                .map_or(HashSet::default(), |live| live.iter().cloned().collect()),
+
+            drop_live_vars: output
+                .var_drop_live_at
+                .get(&point)
+                .map_or(HashSet::default(), |live| live.iter().cloned().collect()),
+            cfg_points: vec![point],
+        }
+    }
+}
+
+fn render_cfg_label(node: &Liveness, intern: &InternerTables) -> String {
+    let mut cfg_points = node.cfg_points.clone();
+    cfg_points.sort();
+
+    let mut fragments = vec![if cfg_points.len() <= 3 {
+        node.cfg_points
+            .iter()
+            .map(|p| intern.points.untern(*p).replace("\"", ""))
+            .collect::<Vec<String>>()
+            .join(", ")
+    } else {
+        format!(
+            "{}–{}",
+            intern
+                .points
+                .untern(*cfg_points.first().unwrap())
+                .replace("\"", ""),
+            intern
+                .points
+                .untern(*cfg_points.last().unwrap())
+                .replace("\"", "")
+        )
+    }];
+
+    fragments[0].push_str("\\l");
+
+    fragments.extend(node.point_facts.iter().map(|(label, var, pt)| {
+        format!(
+            "{}({}, {}).",
+            label,
+            intern.variables.untern(*var).replace("\"", ""),
+            intern.points.untern(*pt).replace("\"", ""),
+        )
+    }));
+
+    fragments.join("\\l")
+}
+
+pub(crate) fn liveness_graph(
+    output: &Output<Region, Loan, Point, Variable>,
+    all_facts: &AllFacts,
+    output_file: &PathBuf,
+    intern: &InternerTables,
+) -> io::Result<()> {
+    info!("Generating liveness graph");
+    let mut file = File::create(output_file)?;
+    let mut output_fragments: Vec<String> = Vec::new();
+    let mut cfg = StableGraph::<Liveness, ()>::new();
+    let mut point_to_node = HashMap::new();
+
+    for &(p1, p2) in all_facts.cfg_edge.iter() {
+        let n1 = *point_to_node
+            .entry(p1)
+            .or_insert_with(|| cfg.add_node(Liveness::from_polonius_data(output, all_facts, p1)));
+
+        let n2 = *point_to_node
+            .entry(p2)
+            .or_insert_with(|| cfg.add_node(Liveness::from_polonius_data(output, all_facts, p2)));
+
+        cfg.add_edge(n1, n2, ());
+    }
+
+    info!("Reducing the liveness graph...");
+    // CFG state reduction
+    if let Some((first_point, _)) = all_facts.cfg_edge.first() {
+        let first_node = *point_to_node.get(first_point).unwrap();
+        let mut dfs = Dfs::new(&cfg, first_node);
+
+        while let Some(node) = dfs.next(&cfg) {
+            let out_degree = cfg.neighbors_directed(node, Outgoing).count();
+            let in_degree = cfg.neighbors_directed(node, Incoming).count();
+
+            // if we have an in-degree and out-degree of 1, we can safely merge
+            // this node into the next one. Note that this check keeps the first
+            // and last nodes!
+            if out_degree == 1 && in_degree == 1 {
+                let previous_node_idx = cfg
+                    .neighbors_directed(node, Incoming)
+                    .detach()
+                    .next_node(&cfg)
+                    .unwrap();
+
+                let next_node_idx = cfg.neighbors(node).detach().next_node(&cfg).unwrap();
+
+                let edge_live_set_before = edge_live_vars(&cfg[previous_node_idx], &cfg[node]);
+                let edge_live_set_after = edge_live_vars(&cfg[node], &cfg[next_node_idx]);
+
+                if edge_live_set_before == edge_live_set_after {
+                    let node_data = cfg.remove_node(node).unwrap();
+                    cfg[next_node_idx].extend(node_data);
+                    cfg.add_edge(previous_node_idx, next_node_idx, ());
+                }
+            }
+        }
+    }
+
+    output_fragments.push("digraph g {\n  graph [\n  rankdir = \"TD\"\n];\n".to_string()); // open digraph
+
+    // output the nodes:
+    output_fragments.push(
+        cfg.node_references()
+            .map(|(node_idx, node_data)| {
+                format!(
+                    "{} [shape=\"record\" label=\"{}\"]",
+                    cfg.to_index(node_idx),
+                    render_cfg_label(node_data, intern)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+
+    output_fragments.push("\n\n".to_string());
+
+    let mut edge_fragments = Vec::new();
+
+    let colour_palette = vec![
+        "#C6CDF7", "#899DA4", "#F98400", "#C7B19C", "#D67236", "#0F0D0E", "#FAEFD1", "#ECCBAE",
+        "#E1AF00", "#74A089", "#DD8D29", "#85D4E3", "#1C1718", "#F8AFA8", "#CB2314", "#35274A",
+        "#E1BD6D", "#FDDDA0", "#FD6467", "#ABDDDE", "#F2300F", "#D8B70A", "#EAD3BF", "#1E1E1E",
+        "#273046", "#9C964A", "#046C9A", "#D9D0D3", "#FDD262", "#0B775E", "#4E2A1E", "#EABE94",
+        "#D69C4E", "#E58601", "#F2AD00", "#CCC591", "#E1BD6D", "#35274A", "#FAD510", "#9B110E",
+        "#81A88D", "#CEAB07", "#A42820", "#78B7C5", "#3F5151", "#B40F20", "#354823", "#F2300F",
+        "#5B1A18", "#F3DF6C", "#DC863B", "#02401B", "#FAD77B", "#F1BB7B", "#7294D4", "#EABE94",
+        "#39312F", "#550307", "#EBCC2A", "#972D15", "#A2A475", "#C27D38", "#24281A", "#0C1707",
+        "#0B775E", "#D3DDDC", "#00A08A", "#F21A00", "#3B9AB2", "#E6A0C4", "#CDC08C", "#FF0000",
+        "#9986A5", "#D5D5D3", "#79402E", "#D8A499", "#9A8822", "#46ACC8", "#CCBA72", "#E2D200",
+        "#AA9486", "#F4B5BD", "#446455", "#8D8680", "#5BBCD6", "#798E87", "#5F5647", "#C93312",
+        "#29211F", "#B6854D", "#e1f7d5", "#ffbdbd", "#c9c9ff", "#f1cbff",
+    ];
+
+    for edge in cfg.edge_references() {
+        let edge_live_vars = edge_live_vars(&cfg[edge.source()], &cfg[edge.target()]);
+
+        for &v in edge_live_vars.iter() {
+            let liveness_status = vec![
+                if cfg[edge.source()].use_live_vars.contains(&v) {
+                    "U"
+                } else {
+                    ""
+                },
+                if cfg[edge.source()].drop_live_vars.contains(&v) {
+                    "D"
+                } else {
+                    ""
+                },
+            ]
+            .join("");
+
+            edge_fragments.push(format!(
+                "{} -> {} [label=\" {} {}\", color=\"{}\", penwidth = 2 arrowhead = none]",
+                cfg.to_index(edge.target()),
+                cfg.to_index(edge.source()),
+                intern.variables.untern(v).replace("\"", ""),
+                liveness_status,
+                colour_palette[v.index() % colour_palette.len()],
+            ));
+        }
+
+        edge_fragments.push(format!(
+            "{} -> {} [penwidth = 2]",
+            cfg.to_index(edge.source()),
+            cfg.to_index(edge.target())
+        ));
+    }
+
+    output_fragments.push(edge_fragments.join("\n"));
+
+    output_fragments.push("\n}".to_string()); // close digraph
+    let output_bytes = output_fragments.join("").bytes().collect::<Vec<_>>();
+    file.write_all(&output_bytes)?;
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,6 @@ mod test;
 mod test_util;
 
 pub mod cli;
+
 extern crate log;
+extern crate petgraph;


### PR DESCRIPTION
Uses Petgraph to reduce boring parts (completely linear sections with no changes in liveness of any variable) of the CFG; adds liveness edges with nice colours.

This only affects the Polonius CLI wrapper.