### PR TITLE
Clean up terminology: step 1 — rename `Region` to `Origin`

### DIFF
--- a/polonius-engine/src/facts.rs
+++ b/polonius-engine/src/facts.rs
@@ -64,7 +64,9 @@ pub struct AllFacts<Origin: Atom, Loan: Atom, Point: Atom, Variable: Atom, MoveP
     pub path_accessed_at: Vec<(MovePath, Point)>,
 }
 
-impl<Origin: Atom, Loan: Atom, Point: Atom, Variable: Atom, MovePath: Atom> Default for AllFacts<Origin, Loan, Point, Variable, MovePath> {
+impl<Origin: Atom, Loan: Atom, Point: Atom, Variable: Atom, MovePath: Atom> Default
+    for AllFacts<Origin, Loan, Point, Variable, MovePath>
+{
     fn default() -> Self {
         AllFacts {
             borrow_region: Vec::default(),

--- a/polonius-engine/src/facts.rs
+++ b/polonius-engine/src/facts.rs
@@ -3,14 +3,14 @@ use std::hash::Hash;
 
 /// The "facts" which are the basis of the NLL borrow analysis.
 #[derive(Clone, Debug)]
-pub struct AllFacts<R: Atom, L: Atom, P: Atom, V: Atom, M: Atom> {
-    /// `borrow_region(R, B, P)` -- the region R may refer to data
+pub struct AllFacts<Origin: Atom, L: Atom, P: Atom, V: Atom, M: Atom> {
+    /// `borrow_region(O, B, P)` -- the origin `O` may refer to data
     /// from borrow B starting at the point P (this is usually the
     /// point *after* a borrow rvalue)
-    pub borrow_region: Vec<(R, L, P)>,
+    pub borrow_region: Vec<(Origin, L, P)>,
 
-    /// `universal_region(R)` -- this is a "free region" within fn body
-    pub universal_region: Vec<R>,
+    /// `universal_region(O)` -- this is a "free region" within fn body
+    pub universal_region: Vec<Origin>,
 
     /// `cfg_edge(P,Q)` for each edge P -> Q in the control flow
     pub cfg_edge: Vec<(P, P)>,
@@ -18,8 +18,8 @@ pub struct AllFacts<R: Atom, L: Atom, P: Atom, V: Atom, M: Atom> {
     /// `killed(B,P)` when some prefix of the path borrowed at B is assigned at point P
     pub killed: Vec<(L, P)>,
 
-    /// `outlives(R1, R2, P)` when we require `R1@P: R2@P`
-    pub outlives: Vec<(R, R, P)>,
+    /// `outlives(O1, P2, P)` when we require `O1@P: O2@P`
+    pub outlives: Vec<(Origin, Origin, P)>,
 
     ///  `invalidates(P, L)` when the loan L is invalidated at point P
     pub invalidates: Vec<(P, L)>,
@@ -33,12 +33,12 @@ pub struct AllFacts<R: Atom, L: Atom, P: Atom, V: Atom, M: Atom> {
     /// `var_used(V, P) when the variable V is used in a drop at point P`
     pub var_drop_used: Vec<(V, P)>,
 
-    /// `var_uses_region(V, R) when the type of V includes the region R`
-    pub var_uses_region: Vec<(V, R)>,
+    /// `var_uses_region(V, O)` when the type of V includes the origin `O`
+    pub var_uses_region: Vec<(V, Origin)>,
 
-    /// `var_drops_region(V, R) when the type of V includes the region R and uses
-    /// it when dropping`
-    pub var_drops_region: Vec<(V, R)>,
+    /// `var_drops_region(V, O)` when the type of V includes the origin `O` and uses
+    /// it when dropping
+    pub var_drops_region: Vec<(V, Origin)>,
 
     /// `child(M1, M2) when the move path `M1` is the direct or transitive child
     /// of `M2`, e.g. `child(x.y, x)`, `child(x.y.z, x.y)`, `child(x.y.z, x)`
@@ -64,7 +64,7 @@ pub struct AllFacts<R: Atom, L: Atom, P: Atom, V: Atom, M: Atom> {
     pub path_accessed_at: Vec<(M, P)>,
 }
 
-impl<R: Atom, L: Atom, P: Atom, V: Atom, M: Atom> Default for AllFacts<R, L, P, V, M> {
+impl<Origin: Atom, L: Atom, P: Atom, V: Atom, M: Atom> Default for AllFacts<Origin, L, P, V, M> {
     fn default() -> Self {
         AllFacts {
             borrow_region: Vec::default(),

--- a/polonius-engine/src/facts.rs
+++ b/polonius-engine/src/facts.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 
 /// The "facts" which are the basis of the NLL borrow analysis.
 #[derive(Clone, Debug)]
-pub struct AllFacts<Origin: Atom, Loan: Atom, Point: Atom, Variable: Atom, M: Atom> {
+pub struct AllFacts<Origin: Atom, Loan: Atom, Point: Atom, Variable: Atom, MovePath: Atom> {
     /// `borrow_region(O, L, P)` -- the origin `O` may refer to data
     /// from loan `L` starting at the point `P` (this is usually the
     /// point *after* a borrow rvalue)
@@ -43,28 +43,28 @@ pub struct AllFacts<Origin: Atom, Loan: Atom, Point: Atom, Variable: Atom, M: At
     /// `child(M1, M2)` when the move path `M1` is the direct or transitive child
     /// of `M2`, e.g. `child(x.y, x)`, `child(x.y.z, x.y)`, `child(x.y.z, x)`
     /// would all be true if there was a path like `x.y.z`.
-    pub child: Vec<(M, M)>,
+    pub child: Vec<(MovePath, MovePath)>,
 
     /// `path_belongs_to_var(M, V)` the root path `M` starting in variable `V`.
-    pub path_belongs_to_var: Vec<(M, Variable)>,
+    pub path_belongs_to_var: Vec<(MovePath, Variable)>,
 
     /// `initialized_at(M, P)` when the move path `M` was initialized at point
     /// `P`. This fact is only emitted for a prefix `M`, and not for the
     /// implicit initialization of all of `M`'s children. E.g. a statement like
     /// `x.y = 3` at point `P` would give the fact `initialized_at(x.y, P)` (but
     /// neither `initialized_at(x.y.z, P)` nor `initialized_at(x, P)`).
-    pub initialized_at: Vec<(M, Point)>,
+    pub initialized_at: Vec<(MovePath, Point)>,
 
     /// `moved_out_at(M, P)` when the move path `M` was moved at point `P`. The
     /// same logic is applied as for `initialized_at` above.
-    pub moved_out_at: Vec<(M, Point)>,
+    pub moved_out_at: Vec<(MovePath, Point)>,
 
     /// `path_accessed_at(M, P)` when the move path `M` was accessed at point
     /// `P`. The same logic as for `initialized_at` and `moved_out_at` applies.
-    pub path_accessed_at: Vec<(M, Point)>,
+    pub path_accessed_at: Vec<(MovePath, Point)>,
 }
 
-impl<Origin: Atom, Loan: Atom, Point: Atom, Variable: Atom, M: Atom> Default for AllFacts<Origin, Loan, Point, Variable, M> {
+impl<Origin: Atom, Loan: Atom, Point: Atom, Variable: Atom, MovePath: Atom> Default for AllFacts<Origin, Loan, Point, Variable, MovePath> {
     fn default() -> Self {
         AllFacts {
             borrow_region: Vec::default(),

--- a/polonius-engine/src/facts.rs
+++ b/polonius-engine/src/facts.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 
 /// The "facts" which are the basis of the NLL borrow analysis.
 #[derive(Clone, Debug)]
-pub struct AllFacts<Origin: Atom, Loan: Atom, Point: Atom, V: Atom, M: Atom> {
+pub struct AllFacts<Origin: Atom, Loan: Atom, Point: Atom, Variable: Atom, M: Atom> {
     /// `borrow_region(O, L, P)` -- the origin `O` may refer to data
     /// from loan `L` starting at the point `P` (this is usually the
     /// point *after* a borrow rvalue)
@@ -25,20 +25,20 @@ pub struct AllFacts<Origin: Atom, Loan: Atom, Point: Atom, V: Atom, M: Atom> {
     pub invalidates: Vec<(Point, Loan)>,
 
     /// `var_used(V, P)` when the variable `V` is used for anything but a drop at point `P`
-    pub var_used: Vec<(V, Point)>,
+    pub var_used: Vec<(Variable, Point)>,
 
     /// `var_defined(V, P)` when the variable `V` is overwritten by the point `P`
-    pub var_defined: Vec<(V, Point)>,
+    pub var_defined: Vec<(Variable, Point)>,
 
     /// `var_used(V, P)` when the variable `V` is used in a drop at point `P`
-    pub var_drop_used: Vec<(V, Point)>,
+    pub var_drop_used: Vec<(Variable, Point)>,
 
     /// `var_uses_region(V, O)` when the type of `V` includes the origin `O`
-    pub var_uses_region: Vec<(V, Origin)>,
+    pub var_uses_region: Vec<(Variable, Origin)>,
 
     /// `var_drops_region(V, O)` when the type of `V` includes the origin `O` and uses
     /// it when dropping
-    pub var_drops_region: Vec<(V, Origin)>,
+    pub var_drops_region: Vec<(Variable, Origin)>,
 
     /// `child(M1, M2)` when the move path `M1` is the direct or transitive child
     /// of `M2`, e.g. `child(x.y, x)`, `child(x.y.z, x.y)`, `child(x.y.z, x)`
@@ -46,7 +46,7 @@ pub struct AllFacts<Origin: Atom, Loan: Atom, Point: Atom, V: Atom, M: Atom> {
     pub child: Vec<(M, M)>,
 
     /// `path_belongs_to_var(M, V)` the root path `M` starting in variable `V`.
-    pub path_belongs_to_var: Vec<(M, V)>,
+    pub path_belongs_to_var: Vec<(M, Variable)>,
 
     /// `initialized_at(M, P)` when the move path `M` was initialized at point
     /// `P`. This fact is only emitted for a prefix `M`, and not for the
@@ -64,7 +64,7 @@ pub struct AllFacts<Origin: Atom, Loan: Atom, Point: Atom, V: Atom, M: Atom> {
     pub path_accessed_at: Vec<(M, Point)>,
 }
 
-impl<Origin: Atom, Loan: Atom, Point: Atom, V: Atom, M: Atom> Default for AllFacts<Origin, Loan, Point, V, M> {
+impl<Origin: Atom, Loan: Atom, Point: Atom, Variable: Atom, M: Atom> Default for AllFacts<Origin, Loan, Point, Variable, M> {
     fn default() -> Self {
         AllFacts {
             borrow_region: Vec::default(),

--- a/polonius-engine/src/facts.rs
+++ b/polonius-engine/src/facts.rs
@@ -4,8 +4,8 @@ use std::hash::Hash;
 /// The "facts" which are the basis of the NLL borrow analysis.
 #[derive(Clone, Debug)]
 pub struct AllFacts<Origin: Atom, Loan: Atom, P: Atom, V: Atom, M: Atom> {
-    /// `borrow_region(O, B, P)` -- the origin `O` may refer to data
-    /// from borrow B starting at the point P (this is usually the
+    /// `borrow_region(O, L, P)` -- the origin `O` may refer to data
+    /// from loan `L` starting at the point P (this is usually the
     /// point *after* a borrow rvalue)
     pub borrow_region: Vec<(Origin, Loan, P)>,
 
@@ -15,7 +15,7 @@ pub struct AllFacts<Origin: Atom, Loan: Atom, P: Atom, V: Atom, M: Atom> {
     /// `cfg_edge(P,Q)` for each edge P -> Q in the control flow
     pub cfg_edge: Vec<(P, P)>,
 
-    /// `killed(B,P)` when some prefix of the path borrowed at B is assigned at point P
+    /// `killed(L,P)` when some prefix of the path borrowed at `L` is assigned at point `P`
     pub killed: Vec<(Loan, P)>,
 
     /// `outlives(O1, P2, P)` when we require `O1@P: O2@P`

--- a/polonius-engine/src/facts.rs
+++ b/polonius-engine/src/facts.rs
@@ -3,11 +3,11 @@ use std::hash::Hash;
 
 /// The "facts" which are the basis of the NLL borrow analysis.
 #[derive(Clone, Debug)]
-pub struct AllFacts<Origin: Atom, L: Atom, P: Atom, V: Atom, M: Atom> {
+pub struct AllFacts<Origin: Atom, Loan: Atom, P: Atom, V: Atom, M: Atom> {
     /// `borrow_region(O, B, P)` -- the origin `O` may refer to data
     /// from borrow B starting at the point P (this is usually the
     /// point *after* a borrow rvalue)
-    pub borrow_region: Vec<(Origin, L, P)>,
+    pub borrow_region: Vec<(Origin, Loan, P)>,
 
     /// `universal_region(O)` -- this is a "free region" within fn body
     pub universal_region: Vec<Origin>,
@@ -16,13 +16,13 @@ pub struct AllFacts<Origin: Atom, L: Atom, P: Atom, V: Atom, M: Atom> {
     pub cfg_edge: Vec<(P, P)>,
 
     /// `killed(B,P)` when some prefix of the path borrowed at B is assigned at point P
-    pub killed: Vec<(L, P)>,
+    pub killed: Vec<(Loan, P)>,
 
     /// `outlives(O1, P2, P)` when we require `O1@P: O2@P`
     pub outlives: Vec<(Origin, Origin, P)>,
 
-    ///  `invalidates(P, L)` when the loan L is invalidated at point P
-    pub invalidates: Vec<(P, L)>,
+    ///  `invalidates(P, L)` when the loan `L` is invalidated at point `P`
+    pub invalidates: Vec<(P, Loan)>,
 
     /// `var_used(V, P) when the variable V is used for anything but a drop at point P`
     pub var_used: Vec<(V, P)>,
@@ -64,7 +64,7 @@ pub struct AllFacts<Origin: Atom, L: Atom, P: Atom, V: Atom, M: Atom> {
     pub path_accessed_at: Vec<(M, P)>,
 }
 
-impl<Origin: Atom, L: Atom, P: Atom, V: Atom, M: Atom> Default for AllFacts<Origin, L, P, V, M> {
+impl<Origin: Atom, Loan: Atom, P: Atom, V: Atom, M: Atom> Default for AllFacts<Origin, Loan, P, V, M> {
     fn default() -> Self {
         AllFacts {
             borrow_region: Vec::default(),

--- a/polonius-engine/src/facts.rs
+++ b/polonius-engine/src/facts.rs
@@ -12,10 +12,10 @@ pub struct AllFacts<Origin: Atom, Loan: Atom, Point: Atom, V: Atom, M: Atom> {
     /// `universal_region(O)` -- this is a "free region" within fn body
     pub universal_region: Vec<Origin>,
 
-    /// `cfg_edge(P,Q)` for each edge `P -> Q` in the control flow
+    /// `cfg_edge(P, Q)` for each edge `P -> Q` in the control flow
     pub cfg_edge: Vec<(Point, Point)>,
 
-    /// `killed(L,P)` when some prefix of the path borrowed at `L` is assigned at point `P`
+    /// `killed(L, P)` when some prefix of the path borrowed at `L` is assigned at point `P`
     pub killed: Vec<(Loan, Point)>,
 
     /// `outlives(O1, P2, P)` when we require `O1@P: O2@P`
@@ -24,42 +24,42 @@ pub struct AllFacts<Origin: Atom, Loan: Atom, Point: Atom, V: Atom, M: Atom> {
     ///  `invalidates(P, L)` when the loan `L` is invalidated at point `P`
     pub invalidates: Vec<(Point, Loan)>,
 
-    /// `var_used(V, P) when the variable V is used for anything but a drop at point P`
+    /// `var_used(V, P)` when the variable `V` is used for anything but a drop at point `P`
     pub var_used: Vec<(V, Point)>,
 
-    /// `var_defined(V, P) when the variable V is overwritten by the point P`
+    /// `var_defined(V, P)` when the variable `V` is overwritten by the point `P`
     pub var_defined: Vec<(V, Point)>,
 
-    /// `var_used(V, P) when the variable V is used in a drop at point P`
+    /// `var_used(V, P)` when the variable `V` is used in a drop at point `P`
     pub var_drop_used: Vec<(V, Point)>,
 
-    /// `var_uses_region(V, O)` when the type of V includes the origin `O`
+    /// `var_uses_region(V, O)` when the type of `V` includes the origin `O`
     pub var_uses_region: Vec<(V, Origin)>,
 
-    /// `var_drops_region(V, O)` when the type of V includes the origin `O` and uses
+    /// `var_drops_region(V, O)` when the type of `V` includes the origin `O` and uses
     /// it when dropping
     pub var_drops_region: Vec<(V, Origin)>,
 
-    /// `child(M1, M2) when the move path `M1` is the direct or transitive child
+    /// `child(M1, M2)` when the move path `M1` is the direct or transitive child
     /// of `M2`, e.g. `child(x.y, x)`, `child(x.y.z, x.y)`, `child(x.y.z, x)`
     /// would all be true if there was a path like `x.y.z`.
     pub child: Vec<(M, M)>,
 
-    /// `path_belongs_to_var(M, V) the root path `M` starting in variable `V`.
+    /// `path_belongs_to_var(M, V)` the root path `M` starting in variable `V`.
     pub path_belongs_to_var: Vec<(M, V)>,
 
-    /// `initialized_at(M, P) when the move path `M` was initialized at point
+    /// `initialized_at(M, P)` when the move path `M` was initialized at point
     /// `P`. This fact is only emitted for a prefix `M`, and not for the
     /// implicit initialization of all of `M`'s children. E.g. a statement like
     /// `x.y = 3` at point `P` would give the fact `initialized_at(x.y, P)` (but
     /// neither `initialized_at(x.y.z, P)` nor `initialized_at(x, P)`).
     pub initialized_at: Vec<(M, Point)>,
 
-    /// `moved_out_at(M, P) when the move path `M` was moved at point `P`. The
+    /// `moved_out_at(M, P)` when the move path `M` was moved at point `P`. The
     /// same logic is applied as for `initialized_at` above.
     pub moved_out_at: Vec<(M, Point)>,
 
-    /// `path_accessed_at(M, P) when the move path `M` was accessed at point
+    /// `path_accessed_at(M, P)` when the move path `M` was accessed at point
     /// `P`. The same logic as for `initialized_at` and `moved_out_at` applies.
     pub path_accessed_at: Vec<(M, Point)>,
 }

--- a/polonius-engine/src/facts.rs
+++ b/polonius-engine/src/facts.rs
@@ -3,35 +3,35 @@ use std::hash::Hash;
 
 /// The "facts" which are the basis of the NLL borrow analysis.
 #[derive(Clone, Debug)]
-pub struct AllFacts<Origin: Atom, Loan: Atom, P: Atom, V: Atom, M: Atom> {
+pub struct AllFacts<Origin: Atom, Loan: Atom, Point: Atom, V: Atom, M: Atom> {
     /// `borrow_region(O, L, P)` -- the origin `O` may refer to data
-    /// from loan `L` starting at the point P (this is usually the
+    /// from loan `L` starting at the point `P` (this is usually the
     /// point *after* a borrow rvalue)
-    pub borrow_region: Vec<(Origin, Loan, P)>,
+    pub borrow_region: Vec<(Origin, Loan, Point)>,
 
     /// `universal_region(O)` -- this is a "free region" within fn body
     pub universal_region: Vec<Origin>,
 
-    /// `cfg_edge(P,Q)` for each edge P -> Q in the control flow
-    pub cfg_edge: Vec<(P, P)>,
+    /// `cfg_edge(P,Q)` for each edge `P -> Q` in the control flow
+    pub cfg_edge: Vec<(Point, Point)>,
 
     /// `killed(L,P)` when some prefix of the path borrowed at `L` is assigned at point `P`
-    pub killed: Vec<(Loan, P)>,
+    pub killed: Vec<(Loan, Point)>,
 
     /// `outlives(O1, P2, P)` when we require `O1@P: O2@P`
-    pub outlives: Vec<(Origin, Origin, P)>,
+    pub outlives: Vec<(Origin, Origin, Point)>,
 
     ///  `invalidates(P, L)` when the loan `L` is invalidated at point `P`
-    pub invalidates: Vec<(P, Loan)>,
+    pub invalidates: Vec<(Point, Loan)>,
 
     /// `var_used(V, P) when the variable V is used for anything but a drop at point P`
-    pub var_used: Vec<(V, P)>,
+    pub var_used: Vec<(V, Point)>,
 
     /// `var_defined(V, P) when the variable V is overwritten by the point P`
-    pub var_defined: Vec<(V, P)>,
+    pub var_defined: Vec<(V, Point)>,
 
     /// `var_used(V, P) when the variable V is used in a drop at point P`
-    pub var_drop_used: Vec<(V, P)>,
+    pub var_drop_used: Vec<(V, Point)>,
 
     /// `var_uses_region(V, O)` when the type of V includes the origin `O`
     pub var_uses_region: Vec<(V, Origin)>,
@@ -53,18 +53,18 @@ pub struct AllFacts<Origin: Atom, Loan: Atom, P: Atom, V: Atom, M: Atom> {
     /// implicit initialization of all of `M`'s children. E.g. a statement like
     /// `x.y = 3` at point `P` would give the fact `initialized_at(x.y, P)` (but
     /// neither `initialized_at(x.y.z, P)` nor `initialized_at(x, P)`).
-    pub initialized_at: Vec<(M, P)>,
+    pub initialized_at: Vec<(M, Point)>,
 
     /// `moved_out_at(M, P) when the move path `M` was moved at point `P`. The
     /// same logic is applied as for `initialized_at` above.
-    pub moved_out_at: Vec<(M, P)>,
+    pub moved_out_at: Vec<(M, Point)>,
 
     /// `path_accessed_at(M, P) when the move path `M` was accessed at point
     /// `P`. The same logic as for `initialized_at` and `moved_out_at` applies.
-    pub path_accessed_at: Vec<(M, P)>,
+    pub path_accessed_at: Vec<(M, Point)>,
 }
 
-impl<Origin: Atom, Loan: Atom, P: Atom, V: Atom, M: Atom> Default for AllFacts<Origin, Loan, P, V, M> {
+impl<Origin: Atom, Loan: Atom, Point: Atom, V: Atom, M: Atom> Default for AllFacts<Origin, Loan, Point, V, M> {
     fn default() -> Self {
         AllFacts {
             borrow_region: Vec::default(),

--- a/polonius-engine/src/output/hybrid.rs
+++ b/polonius-engine/src/output/hybrid.rs
@@ -16,10 +16,10 @@ use crate::output::location_insensitive;
 use crate::output::Output;
 use facts::{AllFacts, Atom};
 
-pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom, Variable: Atom, MovePath: Atom>(
+pub(super) fn compute<Origin: Atom, Loan: Atom, Point: Atom, Variable: Atom, MovePath: Atom>(
     dump_enabled: bool,
-    all_facts: AllFacts<Region, Loan, Point, Variable, MovePath>,
-) -> Output<Region, Loan, Point, Variable, MovePath> {
+    all_facts: AllFacts<Origin, Loan, Point, Variable, MovePath>,
+) -> Output<Origin, Loan, Point, Variable, MovePath> {
     let lins_output = location_insensitive::compute(dump_enabled, &all_facts);
     if lins_output.errors.is_empty() {
         lins_output

--- a/polonius-engine/src/output/initialization.rs
+++ b/polonius-engine/src/output/initialization.rs
@@ -5,17 +5,17 @@ use facts::Atom;
 
 use datafrog::{Iteration, Relation, RelationLeaper};
 
-pub(super) fn init_var_maybe_initialized_on_exit<Region, Loan, Point, Variable, MovePath>(
+pub(super) fn init_var_maybe_initialized_on_exit<Origin, Loan, Point, Variable, MovePath>(
     child: Vec<(MovePath, MovePath)>,
     path_belongs_to_var: Vec<(MovePath, Variable)>,
     initialized_at: Vec<(MovePath, Point)>,
     moved_out_at: Vec<(MovePath, Point)>,
     path_accessed_at: Vec<(MovePath, Point)>,
     cfg_edge: &[(Point, Point)],
-    output: &mut Output<Region, Loan, Point, Variable, MovePath>,
+    output: &mut Output<Origin, Loan, Point, Variable, MovePath>,
 ) -> Vec<(Variable, Point)>
 where
-    Region: Atom,
+    Origin: Atom,
     Loan: Atom,
     Point: Atom,
     Variable: Atom,

--- a/polonius-engine/src/output/liveness.rs
+++ b/polonius-engine/src/output/liveness.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! An implementation of the region liveness calculation logic
+//! An implementation of the origin liveness calculation logic
 
 use std::collections::BTreeSet;
 use std::time::Instant;
@@ -18,18 +18,18 @@ use facts::Atom;
 
 use datafrog::{Iteration, Relation, RelationLeaper};
 
-pub(super) fn compute_live_regions<Region, Loan, Point, Variable, MovePath>(
+pub(super) fn compute_live_regions<Origin, Loan, Point, Variable, MovePath>(
     var_used: Vec<(Variable, Point)>,
     var_drop_used: Vec<(Variable, Point)>,
     var_defined: Vec<(Variable, Point)>,
-    var_uses_region: Vec<(Variable, Region)>,
-    var_drops_region: Vec<(Variable, Region)>,
+    var_uses_region: Vec<(Variable, Origin)>,
+    var_drops_region: Vec<(Variable, Origin)>,
     cfg_edge: &[(Point, Point)],
     var_maybe_initialized_on_exit: Vec<(Variable, Point)>,
-    output: &mut Output<Region, Loan, Point, Variable, MovePath>,
-) -> Vec<(Region, Point)>
+    output: &mut Output<Origin, Loan, Point, Variable, MovePath>,
+) -> Vec<(Origin, Point)>
 where
-    Region: Atom,
+    Origin: Atom,
     Loan: Atom,
     Point: Atom,
     Variable: Atom,
@@ -44,8 +44,8 @@ where
     let cfg_edge_rel: Relation<(Point, Point)> = cfg_edge.iter().map(|(p, q)| (*p, *q)).collect();
     let cfg_edge_reverse_rel: Relation<(Point, Point)> =
         cfg_edge.iter().map(|(p, q)| (*q, *p)).collect();
-    let var_uses_region_rel: Relation<(Variable, Region)> = var_uses_region.into();
-    let var_drops_region_rel: Relation<(Variable, Region)> = var_drops_region.into();
+    let var_uses_region_rel: Relation<(Variable, Origin)> = var_uses_region.into();
+    let var_drops_region_rel: Relation<(Variable, Origin)> = var_drops_region.into();
     let var_maybe_initialized_on_exit_rel: Relation<(Variable, Point)> =
         var_maybe_initialized_on_exit.into();
     let var_drop_used_rel: Relation<((Variable, Point), ())> = var_drop_used
@@ -61,7 +61,7 @@ where
     let var_drop_live_var = iteration.variable::<(Variable, Point)>("var_drop_live_at");
 
     // This is what we are actually calculating:
-    let region_live_at_var = iteration.variable::<((Region, Point), ())>("region_live_at");
+    let region_live_at_var = iteration.variable::<((Origin, Point), ())>("region_live_at");
 
     // This propagates the relation `var_live(V, P) :- var_used(V, P)`:
     var_live_var.insert(var_used.into());
@@ -163,10 +163,10 @@ where
         .collect()
 }
 
-pub(super) fn make_universal_region_live<Region: Atom, Point: Atom>(
-    region_live_at: &mut Vec<(Region, Point)>,
+pub(super) fn make_universal_region_live<Origin: Atom, Point: Atom>(
+    region_live_at: &mut Vec<(Origin, Point)>,
     cfg_edge: &[(Point, Point)],
-    universal_region: Vec<Region>,
+    universal_region: Vec<Origin>,
 ) {
     debug!("make_universal_regions_live()");
 
@@ -185,7 +185,7 @@ pub(super) fn make_universal_region_live<Region: Atom, Point: Atom>(
 }
 
 pub(super) fn init_region_live_at<
-    Region: Atom,
+    Origin: Atom,
     Loan: Atom,
     Point: Atom,
     Variable: Atom,
@@ -194,13 +194,13 @@ pub(super) fn init_region_live_at<
     var_used: Vec<(Variable, Point)>,
     var_drop_used: Vec<(Variable, Point)>,
     var_defined: Vec<(Variable, Point)>,
-    var_uses_region: Vec<(Variable, Region)>,
-    var_drops_region: Vec<(Variable, Region)>,
+    var_uses_region: Vec<(Variable, Origin)>,
+    var_drops_region: Vec<(Variable, Origin)>,
     var_maybe_initialized_on_exit: Vec<(Variable, Point)>,
     cfg_edge: &[(Point, Point)],
-    universal_region: Vec<Region>,
-    output: &mut Output<Region, Loan, Point, Variable, MovePath>,
-) -> Vec<(Region, Point)> {
+    universal_region: Vec<Origin>,
+    output: &mut Output<Origin, Loan, Point, Variable, MovePath>,
+) -> Vec<(Origin, Point)> {
     debug!("init_region_live_at()");
     let mut region_live_at = compute_live_regions(
         var_used,

--- a/polonius-engine/src/output/location_insensitive.rs
+++ b/polonius-engine/src/output/location_insensitive.rs
@@ -18,10 +18,10 @@ use crate::output::Output;
 use datafrog::{Iteration, Relation, RelationLeaper};
 use facts::{AllFacts, Atom};
 
-pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom, Variable: Atom, MovePath: Atom>(
+pub(super) fn compute<Origin: Atom, Loan: Atom, Point: Atom, Variable: Atom, MovePath: Atom>(
     dump_enabled: bool,
-    all_facts: &AllFacts<Region, Loan, Point, Variable, MovePath>,
-) -> Output<Region, Loan, Point, Variable, MovePath> {
+    all_facts: &AllFacts<Origin, Loan, Point, Variable, MovePath>,
+) -> Output<Origin, Loan, Point, Variable, MovePath> {
     let mut result = Output::new(dump_enabled);
     let var_maybe_initialized_on_exit = initialization::init_var_maybe_initialized_on_exit(
         all_facts.child.clone(),
@@ -51,12 +51,12 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom, Variable: Atom, Mov
         let mut iteration = Iteration::new();
 
         // static inputs
-        let region_live_at: Relation<(Region, Point)> = region_live_at.into();
+        let region_live_at: Relation<(Origin, Point)> = region_live_at.into();
         let invalidates = Relation::from_iter(all_facts.invalidates.iter().map(|&(b, p)| (p, b)));
 
         // .. some variables, ..
-        let subset = iteration.variable::<(Region, Region)>("subset");
-        let requires = iteration.variable::<(Region, Loan)>("requires");
+        let subset = iteration.variable::<(Origin, Origin)>("subset");
+        let requires = iteration.variable::<(Origin, Loan)>("requires");
 
         let potential_errors = iteration.variable::<(Loan, Point)>("potential_errors");
 
@@ -103,20 +103,20 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom, Variable: Atom, Mov
             }
 
             let requires = requires.complete();
-            for (region, borrow) in &requires.elements {
+            for (origin, borrow) in &requires.elements {
                 result
                     .restricts_anywhere
-                    .entry(*region)
+                    .entry(*origin)
                     .or_insert(BTreeSet::new())
                     .insert(*borrow);
             }
 
-            for (region, location) in &region_live_at.elements {
+            for (origin, location) in &region_live_at.elements {
                 result
                     .region_live_at
                     .entry(*location)
                     .or_insert(vec![])
-                    .push(*region);
+                    .push(*origin);
             }
         }
 

--- a/polonius-engine/src/output/mod.rs
+++ b/polonius-engine/src/output/mod.rs
@@ -62,10 +62,10 @@ impl ::std::str::FromStr for Algorithm {
 }
 
 #[derive(Clone, Debug)]
-pub struct Output<Region, Loan, Point, Variable, MovePath>
+pub struct Output<Origin, Loan, Point, Variable, MovePath>
 where
-    Region: Atom,
-    Region: Atom,
+    Origin: Atom,
+    Origin: Atom,
     Loan: Atom,
     Point: Atom,
     Variable: Atom,
@@ -77,12 +77,12 @@ where
 
     // these are just for debugging
     pub borrow_live_at: FxHashMap<Point, Vec<Loan>>,
-    pub restricts: FxHashMap<Point, BTreeMap<Region, BTreeSet<Loan>>>,
-    pub restricts_anywhere: FxHashMap<Region, BTreeSet<Loan>>,
-    pub region_live_at: FxHashMap<Point, Vec<Region>>,
+    pub restricts: FxHashMap<Point, BTreeMap<Origin, BTreeSet<Loan>>>,
+    pub restricts_anywhere: FxHashMap<Origin, BTreeSet<Loan>>,
+    pub region_live_at: FxHashMap<Point, Vec<Origin>>,
     pub invalidates: FxHashMap<Point, Vec<Loan>>,
-    pub subset: FxHashMap<Point, BTreeMap<Region, BTreeSet<Region>>>,
-    pub subset_anywhere: FxHashMap<Region, BTreeSet<Region>>,
+    pub subset: FxHashMap<Point, BTreeMap<Origin, BTreeSet<Origin>>>,
+    pub subset_anywhere: FxHashMap<Origin, BTreeSet<Origin>>,
     pub var_live_at: FxHashMap<Point, Vec<Variable>>,
     pub var_drop_live_at: FxHashMap<Point, Vec<Variable>>,
     pub path_maybe_initialized_at: FxHashMap<Point, Vec<MovePath>>,
@@ -125,16 +125,16 @@ fn compare_errors<Loan: Atom, Point: Atom>(
     differ
 }
 
-impl<Region, Loan, Point, Variable, MovePath> Output<Region, Loan, Point, Variable, MovePath>
+impl<Origin, Loan, Point, Variable, MovePath> Output<Origin, Loan, Point, Variable, MovePath>
 where
-    Region: Atom,
+    Origin: Atom,
     Loan: Atom,
     Point: Atom,
     Variable: Atom,
     MovePath: Atom,
 {
     pub fn compute(
-        all_facts: &AllFacts<Region, Loan, Point, Variable, MovePath>,
+        all_facts: &AllFacts<Origin, Loan, Point, Variable, MovePath>,
         algorithm: Algorithm,
         dump_enabled: bool,
     ) -> Self {
@@ -194,7 +194,7 @@ where
         }
     }
 
-    pub fn restricts_at(&self, location: Point) -> Cow<'_, BTreeMap<Region, BTreeSet<Loan>>> {
+    pub fn restricts_at(&self, location: Point) -> Cow<'_, BTreeMap<Origin, BTreeSet<Loan>>> {
         assert!(self.dump_enabled);
         match self.restricts.get(&location) {
             Some(map) => Cow::Borrowed(map),
@@ -202,7 +202,7 @@ where
         }
     }
 
-    pub fn regions_live_at(&self, location: Point) -> &[Region] {
+    pub fn regions_live_at(&self, location: Point) -> &[Origin] {
         assert!(self.dump_enabled);
         match self.region_live_at.get(&location) {
             Some(v) => v,
@@ -210,7 +210,7 @@ where
         }
     }
 
-    pub fn subsets_at(&self, location: Point) -> Cow<'_, BTreeMap<Region, BTreeSet<Region>>> {
+    pub fn subsets_at(&self, location: Point) -> Cow<'_, BTreeMap<Origin, BTreeSet<Origin>>> {
         assert!(self.dump_enabled);
         match self.subset.get(&location) {
             Some(v) => Cow::Borrowed(v),

--- a/polonius-engine/src/output/mod.rs
+++ b/polonius-engine/src/output/mod.rs
@@ -65,7 +65,6 @@ impl ::std::str::FromStr for Algorithm {
 pub struct Output<Origin, Loan, Point, Variable, MovePath>
 where
     Origin: Atom,
-    Origin: Atom,
     Loan: Atom,
     Point: Atom,
     Variable: Atom,

--- a/polonius-engine/src/output/naive.rs
+++ b/polonius-engine/src/output/naive.rs
@@ -20,10 +20,10 @@ use facts::{AllFacts, Atom};
 
 use datafrog::{Iteration, Relation, RelationLeaper};
 
-pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom, Variable: Atom, MovePath: Atom>(
+pub(super) fn compute<Origin: Atom, Loan: Atom, Point: Atom, Variable: Atom, MovePath: Atom>(
     dump_enabled: bool,
-    all_facts: AllFacts<Region, Loan, Point, Variable, MovePath>,
-) -> Output<Region, Loan, Point, Variable, MovePath> {
+    all_facts: AllFacts<Origin, Loan, Point, Variable, MovePath>,
+) -> Output<Origin, Loan, Point, Variable, MovePath> {
     let mut result = Output::new(dump_enabled);
 
     let var_maybe_initialized_on_exit = initialization::init_var_maybe_initialized_on_exit(
@@ -57,11 +57,11 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom, Variable: Atom, Mov
         // static inputs
         let cfg_edge_rel: Relation<(Point, Point)> = all_facts.cfg_edge.into();
         let killed_rel: Relation<(Loan, Point)> = all_facts.killed.into();
-        let region_live_at_rel: Relation<(Region, Point)> = region_live_at.into();
+        let region_live_at_rel: Relation<(Origin, Point)> = region_live_at.into();
 
         // .. some variables, ..
-        let subset = iteration.variable::<(Region, Region, Point)>("subset");
-        let requires = iteration.variable::<(Region, Loan, Point)>("requires");
+        let subset = iteration.variable::<(Origin, Origin, Point)>("subset");
+        let requires = iteration.variable::<(Origin, Loan, Point)>("requires");
         let borrow_live_at = iteration.variable::<((Loan, Point), ())>("borrow_live_at");
 
         // `invalidates` facts, stored ready for joins
@@ -76,7 +76,7 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom, Variable: Atom, Mov
 
         // we need `region_live_at` in both variable and relation forms.
         // (respectively, for the regular join and the leapjoin).
-        let region_live_at_var = iteration.variable::<((Region, Point), ())>("region_live_at");
+        let region_live_at_var = iteration.variable::<((Origin, Point), ())>("region_live_at");
 
         // output
         let errors = iteration.variable("errors");
@@ -185,22 +185,22 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom, Variable: Atom, Mov
             }
 
             let requires = requires.complete();
-            for (region, borrow, location) in &requires.elements {
+            for (origin, borrow, location) in &requires.elements {
                 result
                     .restricts
                     .entry(*location)
                     .or_insert_with(BTreeMap::new)
-                    .entry(*region)
+                    .entry(*origin)
                     .or_insert_with(BTreeSet::new)
                     .insert(*borrow);
             }
 
-            for (region, location) in &region_live_at_rel.elements {
+            for (origin, location) in &region_live_at_rel.elements {
                 result
                     .region_live_at
                     .entry(*location)
                     .or_insert_with(Vec::new)
-                    .push(*region);
+                    .push(*origin);
             }
 
             let borrow_live_at = borrow_live_at.complete();

--- a/polonius-engine/src/output/naive.rs
+++ b/polonius-engine/src/output/naive.rs
@@ -81,8 +81,6 @@ pub(super) fn compute<Origin: Atom, Loan: Atom, Point: Atom, Variable: Atom, Mov
         // output
         let errors = iteration.variable("errors");
 
-        //let compute_region_live_at = all_facts.region_live_at.is_empty();
-
         // load initial facts.
         subset.insert(all_facts.outlives.into());
         requires.insert(all_facts.borrow_region.into());

--- a/polonius-parser/src/ir.rs
+++ b/polonius-parser/src/ir.rs
@@ -40,17 +40,17 @@ pub struct Statement {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Effect {
-    Use { regions: Vec<String> },
+    Use { origins: Vec<String> },
     Fact(Fact),
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Fact {
     Outlives { a: String, b: String },
-    BorrowRegionAt { region: String, loan: String },
+    BorrowRegionAt { origin: String, loan: String },
     Invalidates { loan: String },
     Kill { loan: String },
-    RegionLiveAt { region: String },
+    RegionLiveAt { origin: String },
     DefineVariable { variable: String },
     UseVariable { variable: String },
 }

--- a/polonius-parser/src/parser.lalrpop
+++ b/polonius-parser/src/parser.lalrpop
@@ -12,12 +12,12 @@ Comment: () = {
 
 VarRegionMappings = Comma<VarRegionMapping>;
 VarRegionMapping: (String, String) = {
-                 "(" <Variable> "," <Region> ")" => (<>),
+                 "(" <Variable> "," <Origin> ")" => (<>),
 };
 
 VarUsesRegion = "var_uses_region" "{" <VarRegionMappings> "}";
 VarDropsRegion = "var_drops_region" "{" <VarRegionMappings> "}";
-UniversalRegions = "universal_regions" "{" <Comma<Region>> "}";
+UniversalRegions = "universal_regions" "{" <Comma<Origin>> "}";
 BlockDefn : Block = {
     "block" <name:Block> "{" <statements:Statement*> Comment* <goto:Goto> "}" => Block { <> },
 };
@@ -39,17 +39,17 @@ Effect = {
 };
 
 Fact : Fact = {
-  "outlives" "(" <a:Region> ":" <b:Region> ")" => Fact::Outlives { <> },
-  "borrow_region_at" "(" <region:Region> "," <loan:Loan> ")" => Fact::BorrowRegionAt { <> },
+  "outlives" "(" <a:Origin> ":" <b:Origin> ")" => Fact::Outlives { <> },
+  "borrow_region_at" "(" <origin:Origin> "," <loan:Loan> ")" => Fact::BorrowRegionAt { <> },
   "invalidates" "(" <loan:Loan> ")" => Fact::Invalidates { <> },
   "kill" "(" <loan:Loan> ")" => Fact::Kill { <> },
   "var_used" "(" <variable:Variable> ")" => Fact::UseVariable { <> },
   "var_defined" "(" <variable:Variable> ")" => Fact::DefineVariable { <> },
-  "region_live_at" "(" <region:Region> ")" => Fact::RegionLiveAt { <> },
+  "region_live_at" "(" <origin:Origin> ")" => Fact::RegionLiveAt { <> },
   "var_drop_used" "(" <variable:Variable> ")" => Fact::UseVariable { <> },
 };
 
-Use : Effect = "use" "(" <regions:Comma<Region>> ")" => Effect::Use { <> };
+Use : Effect = "use" "(" <origins:Comma<Origin>> ")" => Effect::Use { <> };
 
 Comma<T>: Vec<T> = {
     <v:(<T> ",")*> <e:T?> => match e {
@@ -62,7 +62,7 @@ Comma<T>: Vec<T> = {
     }
 };
 
-Region: String = {
+Origin: String = {
     r"'\w+" => <>.to_string()
 };
 

--- a/polonius-parser/src/tests.rs
+++ b/polonius-parser/src/tests.rs
@@ -77,7 +77,7 @@ fn effects() {
     assert_eq!(
         effects[0],
         Effect::Use {
-            regions: vec!["'a".to_string()]
+            origins: vec!["'a".to_string()]
         }
     );
     assert_eq!(
@@ -90,7 +90,7 @@ fn effects() {
     assert_eq!(
         effects[2],
         Effect::Fact(Fact::BorrowRegionAt {
-            region: "'b".to_string(),
+            origin: "'b".to_string(),
             loan: "L1".to_string()
         })
     );
@@ -137,14 +137,14 @@ fn effects_start() {
                 loan: "L0".to_string()
             }),
             Effect::Fact(Fact::RegionLiveAt {
-                region: "'a".to_string()
+                origin: "'a".to_string()
             })
         ]
     );
     assert_eq!(
         statements.effects,
         [Effect::Use {
-            regions: vec!["'a".to_string()]
+            origins: vec!["'a".to_string()]
         }]
     );
 
@@ -172,7 +172,7 @@ fn effects_start() {
     assert_eq!(
         statements.effects,
         [Effect::Use {
-            regions: vec!["'c".to_string()]
+            origins: vec!["'c".to_string()]
         }]
     );
 }

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -486,7 +486,7 @@ fn build_outputs_by_point_for_visualization(
         ),
         facts_by_point(
             output.region_live_at.iter(),
-            |(pt, region)| (*pt, region.clone()),
+            |(pt, origin)| (*pt, origin.clone()),
             "region_live_at".to_string(),
             1,
             intern,

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -13,7 +13,7 @@ use std::hash::Hash;
 use std::io::{self, Write};
 use std::path::PathBuf;
 
-pub(crate) type Output = PoloniusEngineOutput<Region, Loan, Point, Variable, MovePath>;
+pub(crate) type Output = PoloniusEngineOutput<Origin, Loan, Point, Variable, MovePath>;
 
 pub(crate) fn dump_output(
     output: &Output,
@@ -287,7 +287,7 @@ pub(crate) trait Atom: Copy + From<usize> + Into<usize> {
     fn table(intern: &InternerTables) -> &Interner<Self>;
 }
 
-impl Atom for Region {
+impl Atom for Origin {
     fn table(intern: &InternerTables) -> &Interner<Self> {
         &intern.regions
     }

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -289,7 +289,7 @@ pub(crate) trait Atom: Copy + From<usize> + Into<usize> {
 
 impl Atom for Origin {
     fn table(intern: &InternerTables) -> &Interner<Self> {
-        &intern.regions
+        &intern.origins
     }
 }
 

--- a/src/facts.rs
+++ b/src/facts.rs
@@ -1,6 +1,6 @@
 use polonius_engine;
 
-pub(crate) type AllFacts = polonius_engine::AllFacts<Region, Loan, Point, Variable, MovePath>;
+pub(crate) type AllFacts = polonius_engine::AllFacts<Origin, Loan, Point, Variable, MovePath>;
 
 macro_rules! index_type {
     ($t:ident) => {
@@ -31,7 +31,7 @@ macro_rules! index_type {
     };
 }
 
-index_type!(Region);
+index_type!(Origin);
 index_type!(Loan);
 index_type!(Point);
 index_type!(Variable);

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -41,7 +41,7 @@ where
 }
 
 pub(crate) struct InternerTables {
-    pub(crate) regions: Interner<Region>,
+    pub(crate) regions: Interner<Origin>,
     pub(crate) loans: Interner<Loan>,
     pub(crate) points: Interner<Point>,
     pub(crate) variables: Interner<Variable>,
@@ -74,7 +74,7 @@ macro_rules! intern_impl {
     };
 }
 
-intern_impl!(Region, regions);
+intern_impl!(Origin, regions);
 intern_impl!(Loan, loans);
 intern_impl!(Point, points);
 intern_impl!(Variable, variables);

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -41,7 +41,7 @@ where
 }
 
 pub(crate) struct InternerTables {
-    pub(crate) regions: Interner<Origin>,
+    pub(crate) origins: Interner<Origin>,
     pub(crate) loans: Interner<Loan>,
     pub(crate) points: Interner<Point>,
     pub(crate) variables: Interner<Variable>,
@@ -51,7 +51,7 @@ pub(crate) struct InternerTables {
 impl InternerTables {
     pub(crate) fn new() -> Self {
         Self {
-            regions: Interner::new(),
+            origins: Interner::new(),
             loans: Interner::new(),
             points: Interner::new(),
             variables: Interner::new(),
@@ -74,7 +74,7 @@ macro_rules! intern_impl {
     };
 }
 
-intern_impl!(Origin, regions);
+intern_impl!(Origin, origins);
 intern_impl!(Loan, loans);
 intern_impl!(Point, points);
 intern_impl!(Variable, variables);

--- a/src/program.rs
+++ b/src/program.rs
@@ -7,23 +7,23 @@ use polonius_parser::{
     parse_input,
 };
 
-use crate::facts::{AllFacts, Loan, MovePath, Point, Region, Variable};
+use crate::facts::{AllFacts, Loan, MovePath, Point, Origin, Variable};
 use crate::intern::InternerTables;
 
 /// A structure to hold and deduplicate facts
 #[derive(Default)]
 struct Facts {
-    borrow_region: BTreeSet<(Region, Loan, Point)>,
-    universal_region: BTreeSet<Region>,
+    borrow_region: BTreeSet<(Origin, Loan, Point)>,
+    universal_region: BTreeSet<Origin>,
     cfg_edge: BTreeSet<(Point, Point)>,
     killed: BTreeSet<(Loan, Point)>,
-    outlives: BTreeSet<(Region, Region, Point)>,
+    outlives: BTreeSet<(Origin, Origin, Point)>,
     invalidates: BTreeSet<(Point, Loan)>,
     var_defined: BTreeSet<(Variable, Point)>,
     var_used: BTreeSet<(Variable, Point)>,
     var_drop_used: BTreeSet<(Variable, Point)>,
-    var_uses_region: BTreeSet<(Variable, Region)>,
-    var_drops_region: BTreeSet<(Variable, Region)>,
+    var_uses_region: BTreeSet<(Variable, Origin)>,
+    var_drops_region: BTreeSet<(Variable, Origin)>,
     child: BTreeSet<(MovePath, MovePath)>,
     path_belongs_to_var: BTreeSet<(MovePath, Variable)>,
     initialized_at: BTreeSet<(MovePath, Point)>,
@@ -63,7 +63,7 @@ pub(crate) fn parse_from_program(
 
     let mut facts: Facts = Default::default();
 
-    // facts: universal_region(Region)
+    // facts: universal_region(Origin)
     facts.universal_region.extend(
         input
             .universal_regions
@@ -169,7 +169,7 @@ pub(crate) fn parse_from_program(
 
 fn emit_fact(facts: &mut Facts, fact: &Fact, point: Point, tables: &mut InternerTables) {
     match fact {
-        // facts: borrow_region(Region, Loan, Point)
+        // facts: borrow_region(Origin, Loan, Point)
         Fact::BorrowRegionAt {
             ref region,
             ref loan,
@@ -181,7 +181,7 @@ fn emit_fact(facts: &mut Facts, fact: &Fact, point: Point, tables: &mut Interner
             facts.borrow_region.insert((region, loan, point));
         }
 
-        // facts: outlives(Region, Region, Point)
+        // facts: outlives(Origin, Origin, Point)
         Fact::Outlives { ref a, ref b } => {
             // outlives: a `outlives` occurs on Mid points
             let region_a = tables.regions.intern(a);

--- a/src/program.rs
+++ b/src/program.rs
@@ -68,24 +68,24 @@ pub(crate) fn parse_from_program(
         input
             .universal_regions
             .iter()
-            .map(|region| tables.origins.intern(region)),
+            .map(|origin| tables.origins.intern(origin)),
     );
 
     facts
         .var_drops_region
-        .extend(input.var_drops_region.iter().map(|(variable, region)| {
+        .extend(input.var_drops_region.iter().map(|(variable, origin)| {
             (
                 tables.variables.intern(variable),
-                tables.origins.intern(region),
+                tables.origins.intern(origin),
             )
         }));
 
     facts
         .var_uses_region
-        .extend(input.var_uses_region.iter().map(|(variable, region)| {
+        .extend(input.var_uses_region.iter().map(|(variable, origin)| {
             (
                 tables.variables.intern(variable),
-                tables.origins.intern(region),
+                tables.origins.intern(origin),
             )
         }));
 
@@ -175,10 +175,10 @@ fn emit_fact(facts: &mut Facts, fact: &Fact, point: Point, tables: &mut Interner
             ref loan,
         } => {
             // borrow_region: a `borrow_region_at` occurs on the Mid point
-            let region = tables.origins.intern(region);
+            let origin = tables.origins.intern(region);
             let loan = tables.loans.intern(loan);
 
-            facts.borrow_region.insert((region, loan, point));
+            facts.borrow_region.insert((origin, loan, point));
         }
 
         // facts: outlives(Origin, Origin, Point)
@@ -299,11 +299,11 @@ mod tests {
 
         assert_eq!(facts.borrow_region.len(), 1);
         {
-            let region = tables.origins.untern(facts.borrow_region[0].0);
+            let origin = tables.origins.untern(facts.borrow_region[0].0);
             let loan = tables.loans.untern(facts.borrow_region[0].1);
             let point = tables.points.untern(facts.borrow_region[0].2);
 
-            assert_eq!(region, "'b");
+            assert_eq!(origin, "'b");
             assert_eq!(loan, "L1");
             assert_eq!(point, "\"Mid(B1[0])\"");
         }

--- a/src/program.rs
+++ b/src/program.rs
@@ -7,7 +7,7 @@ use polonius_parser::{
     parse_input,
 };
 
-use crate::facts::{AllFacts, Loan, MovePath, Point, Origin, Variable};
+use crate::facts::{AllFacts, Loan, MovePath, Origin, Point, Variable};
 use crate::intern::InternerTables;
 
 /// A structure to hold and deduplicate facts

--- a/src/program.rs
+++ b/src/program.rs
@@ -68,7 +68,7 @@ pub(crate) fn parse_from_program(
         input
             .universal_regions
             .iter()
-            .map(|region| tables.regions.intern(region)),
+            .map(|region| tables.origins.intern(region)),
     );
 
     facts
@@ -76,7 +76,7 @@ pub(crate) fn parse_from_program(
         .extend(input.var_drops_region.iter().map(|(variable, region)| {
             (
                 tables.variables.intern(variable),
-                tables.regions.intern(region),
+                tables.origins.intern(region),
             )
         }));
 
@@ -85,7 +85,7 @@ pub(crate) fn parse_from_program(
         .extend(input.var_uses_region.iter().map(|(variable, region)| {
             (
                 tables.variables.intern(variable),
-                tables.regions.intern(region),
+                tables.origins.intern(region),
             )
         }));
 
@@ -175,7 +175,7 @@ fn emit_fact(facts: &mut Facts, fact: &Fact, point: Point, tables: &mut Interner
             ref loan,
         } => {
             // borrow_region: a `borrow_region_at` occurs on the Mid point
-            let region = tables.regions.intern(region);
+            let region = tables.origins.intern(region);
             let loan = tables.loans.intern(loan);
 
             facts.borrow_region.insert((region, loan, point));
@@ -184,8 +184,8 @@ fn emit_fact(facts: &mut Facts, fact: &Fact, point: Point, tables: &mut Interner
         // facts: outlives(Origin, Origin, Point)
         Fact::Outlives { ref a, ref b } => {
             // outlives: a `outlives` occurs on Mid points
-            let region_a = tables.regions.intern(a);
-            let region_b = tables.regions.intern(b);
+            let region_a = tables.origins.intern(a);
+            let region_b = tables.origins.intern(b);
 
             facts.outlives.insert((region_a, region_b, point));
         }
@@ -262,7 +262,7 @@ mod tests {
         let universal_regions: Vec<_> = facts
             .universal_region
             .iter()
-            .map(|r| tables.regions.untern(*r).to_string())
+            .map(|r| tables.origins.untern(*r).to_string())
             .collect();
         assert_eq!(universal_regions, ["'a", "'b", "'c"]);
 
@@ -288,8 +288,8 @@ mod tests {
 
         assert_eq!(facts.outlives.len(), 1);
         {
-            let region_a = tables.regions.untern(facts.outlives[0].0);
-            let region_b = tables.regions.untern(facts.outlives[0].1);
+            let region_a = tables.origins.untern(facts.outlives[0].0);
+            let region_b = tables.origins.untern(facts.outlives[0].1);
             let point = tables.points.untern(facts.outlives[0].2);
 
             assert_eq!(region_a, "'a");
@@ -299,7 +299,7 @@ mod tests {
 
         assert_eq!(facts.borrow_region.len(), 1);
         {
-            let region = tables.regions.untern(facts.borrow_region[0].0);
+            let region = tables.origins.untern(facts.borrow_region[0].0);
             let loan = tables.loans.untern(facts.borrow_region[0].1);
             let point = tables.points.untern(facts.borrow_region[0].2);
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -171,11 +171,11 @@ fn emit_fact(facts: &mut Facts, fact: &Fact, point: Point, tables: &mut Interner
     match fact {
         // facts: borrow_region(Origin, Loan, Point)
         Fact::BorrowRegionAt {
-            ref region,
+            ref origin,
             ref loan,
         } => {
-            // borrow_region: a `borrow_region_at` occurs on the Mid point
-            let origin = tables.origins.intern(region);
+            // borrow_region: a `borrow_region` occurs on the Mid point
+            let origin = tables.origins.intern(origin);
             let loan = tables.loans.intern(loan);
 
             facts.borrow_region.insert((origin, loan, point));

--- a/src/test.rs
+++ b/src/test.rs
@@ -162,7 +162,7 @@ fn no_subset_symmetries_exist() -> Result<(), Error> {
 // are extracted from rustc's test suite, and fail because of differences between the Naive
 // and DatafrogOpt variants, on the computation of the transitive closure.
 // They are part of the same pattern that the optimized variant misses, and only differ in
-// the length of the `outlives` chain reaching a live region at a specific point.
+// the length of the `outlives` chain reaching a live origin at a specific point.
 
 #[test]
 fn send_is_not_static_std_sync() {
@@ -223,7 +223,7 @@ fn issue_31567() {
 
 #[test]
 fn borrowed_local_error() {
-    // This test is related to the previous 3: there is still a borrow_region outliving a live region,
+    // This test is related to the previous 3: there is still a borrow_region outliving a live origin,
     // through a chain of `outlives` at a single point, but this time there are also 2 points
     // and an edge.
 


### PR DESCRIPTION
A first step in cleaning up the Polonius terminology by:
- renaming `regions` into `origins` (except in datafrog closures and datalog rules comments, for now)
- whenever a single-letter generic type was used, using the full word instead
- assorted cleanups in comments or leftover random bits and bobs