### PR TITLE
Clean up terminology: step 2 — more renaming, and using actual words

### DIFF
--- a/polonius-engine/src/facts.rs
+++ b/polonius-engine/src/facts.rs
@@ -4,64 +4,64 @@ use std::hash::Hash;
 /// The "facts" which are the basis of the NLL borrow analysis.
 #[derive(Clone, Debug)]
 pub struct AllFacts<T: FactTypes> {
-    /// `borrow_region(O, L, P)` -- the origin `O` may refer to data
-    /// from loan `L` starting at the point `P` (this is usually the
+    /// `borrow_region(origin, loan, point)` -- the `origin` may refer to data
+    /// from `loan` starting at `point` (this is usually the
     /// point *after* a borrow rvalue)
     pub borrow_region: Vec<(T::Origin, T::Loan, T::Point)>,
 
-    /// `universal_region(O)` -- this is a "free region" within fn body
+    /// `universal_region(origin)` -- this is a "free region" within fn body
     pub universal_region: Vec<T::Origin>,
 
-    /// `cfg_edge(P, Q)` for each edge `P -> Q` in the control flow
+    /// `cfg_edge(point1, point2)` for each edge `point1 -> point2` in the control flow
     pub cfg_edge: Vec<(T::Point, T::Point)>,
 
-    /// `killed(L, P)` when some prefix of the path borrowed at `L` is assigned at point `P`
+    /// `killed(loan, point)` when some prefix of the path borrowed at `loan` is assigned at `point`
     pub killed: Vec<(T::Loan, T::Point)>,
 
-    /// `outlives(O1, P2, P)` when we require `O1@P: O2@P`
+    /// `outlives(origin1, origin2, point)` when we require `origin1@point: origin2@point`
     pub outlives: Vec<(T::Origin, T::Origin, T::Point)>,
 
-    ///  `invalidates(P, L)` when the loan `L` is invalidated at point `P`
+    /// `invalidates(point, loan)` when the `loan` is invalidated at `point`
     pub invalidates: Vec<(T::Point, T::Loan)>,
 
-    /// `var_used(V, P)` when the variable `V` is used for anything but a drop at point `P`
+    /// `var_used(var, point)` when the variable `var` is used for anything but a drop at `point`
     pub var_used: Vec<(T::Variable, T::Point)>,
 
-    /// `var_defined(V, P)` when the variable `V` is overwritten by the point `P`
+    /// `var_defined(var, point)` when the variable `var` is overwritten at `point`
     pub var_defined: Vec<(T::Variable, T::Point)>,
 
-    /// `var_used(V, P)` when the variable `V` is used in a drop at point `P`
+    /// `var_used(var, point)` when the variable `var` is used in a drop at `point`
     pub var_drop_used: Vec<(T::Variable, T::Point)>,
 
-    /// `var_uses_region(V, O)` when the type of `V` includes the origin `O`
+    /// `var_uses_region(var, origin)` when the type of `var` includes the `origin`
     pub var_uses_region: Vec<(T::Variable, T::Origin)>,
 
-    /// `var_drops_region(V, O)` when the type of `V` includes the origin `O` and uses
+    /// `var_drops_region(var, origin)` when the type of `var` includes the `origin` and uses
     /// it when dropping
     pub var_drops_region: Vec<(T::Variable, T::Origin)>,
 
-    /// `child(M1, M2)` when the move path `M1` is the direct or transitive child
-    /// of `M2`, e.g. `child(x.y, x)`, `child(x.y.z, x.y)`, `child(x.y.z, x)`
+    /// `child(path1, path2)` when the path `path1` is the direct or transitive child
+    /// of `path2`, e.g. `child(x.y, x)`, `child(x.y.z, x.y)`, `child(x.y.z, x)`
     /// would all be true if there was a path like `x.y.z`.
-    pub child: Vec<(T::MovePath, T::MovePath)>,
+    pub child: Vec<(T::Path, T::Path)>,
 
-    /// `path_belongs_to_var(M, V)` the root path `M` starting in variable `V`.
-    pub path_belongs_to_var: Vec<(T::MovePath, T::Variable)>,
+    /// `path_belongs_to_var(path, var)` the root path `path` starting in variable `var`.
+    pub path_belongs_to_var: Vec<(T::Path, T::Variable)>,
 
-    /// `initialized_at(M, P)` when the move path `M` was initialized at point
-    /// `P`. This fact is only emitted for a prefix `M`, and not for the
-    /// implicit initialization of all of `M`'s children. E.g. a statement like
-    /// `x.y = 3` at point `P` would give the fact `initialized_at(x.y, P)` (but
-    /// neither `initialized_at(x.y.z, P)` nor `initialized_at(x, P)`).
-    pub initialized_at: Vec<(T::MovePath, T::Point)>,
+    /// `initialized_at(path, point)` when the `path` was initialized at point
+    /// `point`. This fact is only emitted for a prefix `path`, and not for the
+    /// implicit initialization of all of `path`'s children. E.g. a statement like
+    /// `x.y = 3` at `point` would give the fact `initialized_at(x.y, point)` (but
+    /// neither `initialized_at(x.y.z, point)` nor `initialized_at(x, point)`).
+    pub initialized_at: Vec<(T::Path, T::Point)>,
 
-    /// `moved_out_at(M, P)` when the move path `M` was moved at point `P`. The
+    /// `moved_out_at(path, point)` when the `path` was moved at `point`. The
     /// same logic is applied as for `initialized_at` above.
-    pub moved_out_at: Vec<(T::MovePath, T::Point)>,
+    pub moved_out_at: Vec<(T::Path, T::Point)>,
 
-    /// `path_accessed_at(M, P)` when the move path `M` was accessed at point
-    /// `P`. The same logic as for `initialized_at` and `moved_out_at` applies.
-    pub path_accessed_at: Vec<(T::MovePath, T::Point)>,
+    /// `path_accessed_at(path, point)` when the `path` was accessed at point
+    /// `point`. The same logic as for `initialized_at` and `moved_out_at` applies.
+    pub path_accessed_at: Vec<(T::Path, T::Point)>,
 }
 
 impl<T: FactTypes> Default for AllFacts<T> {
@@ -98,5 +98,5 @@ pub trait FactTypes: Copy + Clone + Debug {
     type Loan: Atom;
     type Point: Atom;
     type Variable: Atom;
-    type MovePath: Atom;
+    type Path: Atom;
 }

--- a/polonius-engine/src/output/liveness.rs
+++ b/polonius-engine/src/output/liveness.rs
@@ -28,132 +28,137 @@ pub(super) fn compute_live_regions<T: FactTypes>(
     var_maybe_initialized_on_exit: Vec<(T::Variable, T::Point)>,
     output: &mut Output<T>,
 ) -> Vec<(T::Origin, T::Point)> {
-    debug!("compute_liveness()");
     let computation_start = Instant::now();
     let mut iteration = Iteration::new();
 
     // Relations
     let var_defined_rel: Relation<(T::Variable, T::Point)> = var_defined.into();
-    let cfg_edge_rel: Relation<(T::Point, T::Point)> =
-        cfg_edge.iter().map(|(p, q)| (*p, *q)).collect();
-    let cfg_edge_reverse_rel: Relation<(T::Point, T::Point)> =
-        cfg_edge.iter().map(|(p, q)| (*q, *p)).collect();
+    let cfg_edge_rel: Relation<(T::Point, T::Point)> = cfg_edge
+        .iter()
+        .map(|&(point1, point2)| (point1, point2))
+        .collect();
+    let cfg_edge_reverse_rel: Relation<(T::Point, T::Point)> = cfg_edge
+        .iter()
+        .map(|&(point1, point2)| (point2, point1))
+        .collect();
     let var_uses_region_rel: Relation<(T::Variable, T::Origin)> = var_uses_region.into();
     let var_drops_region_rel: Relation<(T::Variable, T::Origin)> = var_drops_region.into();
     let var_maybe_initialized_on_exit_rel: Relation<(T::Variable, T::Point)> =
         var_maybe_initialized_on_exit.into();
     let var_drop_used_rel: Relation<((T::Variable, T::Point), ())> = var_drop_used
         .into_iter()
-        .map(|(v, p)| ((v, p), ()))
+        .map(|(var, point)| ((var, point), ()))
         .collect();
 
-    // T::Variables
+    // Variables
 
-    // `var_live`: variable V is live upon entry in point P
+    // `var_live`: variable `var` is live upon entry at `point`
     let var_live_var = iteration.variable::<(T::Variable, T::Point)>("var_live_at");
-    // `var_drop_live`: variable V is drop-live (will be used for a drop) upon entry in point P
+    // `var_drop_live`: variable `var` is drop-live (will be used for a drop) upon entry in `point`
     let var_drop_live_var = iteration.variable::<(T::Variable, T::Point)>("var_drop_live_at");
 
     // This is what we are actually calculating:
     let region_live_at_var = iteration.variable::<((T::Origin, T::Point), ())>("region_live_at");
 
-    // This propagates the relation `var_live(V, P) :- var_used(V, P)`:
+    // This propagates the relation `var_live(var, point) :- var_used(var, point)`:
     var_live_var.insert(var_used.into());
 
-    // var_maybe_initialized_on_entry(V, Q) :-
-    //     var_maybe_initialized_on_exit(V, P),
-    //     cfg_edge(P, Q).
+    // var_maybe_initialized_on_entry(var, point2) :-
+    //     var_maybe_initialized_on_exit(var, point1),
+    //     cfg_edge(point1, point2).
     let var_maybe_initialized_on_entry = Relation::from_leapjoin(
         &var_maybe_initialized_on_exit_rel,
-        cfg_edge_rel.extend_with(|&(_v, p)| p),
-        |&(v, _p), &q| ((v, q), ()),
+        cfg_edge_rel.extend_with(|&(_var, point1)| point1),
+        |&(var, _point1), &point2| ((var, point2), ()),
     );
 
-    // var_drop_live(V, P) :-
-    //     var_drop_used(V, P),
-    //     var_maybe_initialzed_on_entry(V, P).
+    // var_drop_live(var, point) :-
+    //     var_drop_used(var, point),
+    //     var_maybe_initialzed_on_entry(var, point).
     var_drop_live_var.insert(Relation::from_join(
         &var_drop_used_rel,
         &var_maybe_initialized_on_entry,
-        |&(v, p), &(), &()| (v, p),
+        |&(var, point), _, _| (var, point),
     ));
 
     while iteration.changed() {
-        // region_live_at(R, P) :-
-        //   var_drop_live(V, P),
-        //   var_drops_region(V, R).
-        region_live_at_var.from_join(&var_drop_live_var, &var_drops_region_rel, |_v, &p, &r| {
-            ((r, p), ())
-        });
+        // region_live_at(origin, point) :-
+        //   var_drop_live(var, point),
+        //   var_drops_region(var, origin).
+        region_live_at_var.from_join(
+            &var_drop_live_var,
+            &var_drops_region_rel,
+            |_var, &point, &origin| ((origin, point), ()),
+        );
 
-        // region_live_at(R, P) :-
-        //   var_live(V, P),
-        //   var_uses_region(V, R).
-        region_live_at_var.from_join(&var_live_var, &var_uses_region_rel, |_v, &p, &r| {
-            ((r, p), ())
-        });
+        // region_live_at(origin, point) :-
+        //   var_live(var, point),
+        //   var_uses_region(var, origin).
+        region_live_at_var.from_join(
+            &var_live_var,
+            &var_uses_region_rel,
+            |_var, &point, &origin| ((origin, point), ()),
+        );
 
-        // var_live(V, P) :-
-        //     var_live(V, Q),
-        //     cfg_edge(P, Q),
-        //     !var_defined(V, P).
+        // var_live(var, point1) :-
+        //     var_live(var, point2),
+        //     cfg_edge(point1, point2),
+        //     !var_defined(var, point1).
         var_live_var.from_leapjoin(
             &var_live_var,
             (
-                var_defined_rel.extend_anti(|&(v, _q)| v),
-                cfg_edge_reverse_rel.extend_with(|&(_v, q)| q),
+                var_defined_rel.extend_anti(|&(var, _point2)| var),
+                cfg_edge_reverse_rel.extend_with(|&(_var, point2)| point2),
             ),
-            |&(v, _q), &p| (v, p),
+            |&(var, _point2), &point1| (var, point1),
         );
 
-        // var_drop_live(V, P) :-
-        //     var_drop_live(V, Q),
-        //     cfg_edge(P, Q),
-        //     !var_defined(V, P)
-        //     var_maybe_initialized_on_exit(V, P).
-        // extend p with v:s from q such that v is not in q, there is an edge from p to q
+        // var_drop_live(var, point1) :-
+        //     var_drop_live(var, point2),
+        //     cfg_edge(point1, point2),
+        //     !var_defined(var, point1)
+        //     var_maybe_initialized_on_exit(var, point1).
+        //
+        // Extend `point1` with `var:s` from `point2` such that `var` is not in `point2`,
+        // there is an edge from `point1` to `point2`
         var_drop_live_var.from_leapjoin(
             &var_drop_live_var,
             (
-                var_defined_rel.extend_anti(|&(v, _q)| v),
-                cfg_edge_reverse_rel.extend_with(|&(_v, q)| q),
-                var_maybe_initialized_on_exit_rel.extend_with(|&(v, _q)| v),
+                var_defined_rel.extend_anti(|&(var, _point2)| var),
+                cfg_edge_reverse_rel.extend_with(|&(_var, point2)| point2),
+                var_maybe_initialized_on_exit_rel.extend_with(|&(var, _point2)| var),
             ),
-            |&(v, _q), &p| (v, p),
+            |&(var, _point2), &point1| (var, point1),
         );
     }
 
     let region_live_at_rel = region_live_at_var.complete();
 
     info!(
-        "compute_liveness() completed: {} tuples, {:?}",
+        "compute_live_regions() completed: {} tuples, {:?}",
         region_live_at_rel.len(),
         computation_start.elapsed()
     );
 
     if output.dump_enabled {
         let var_drop_live_at = var_drop_live_var.complete();
-        for &(var, location) in &var_drop_live_at.elements {
+        for &(var, location) in var_drop_live_at.iter() {
             output
                 .var_drop_live_at
                 .entry(location)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(var);
         }
 
         let var_live_at = var_live_var.complete();
-        for &(var, location) in &var_live_at.elements {
-            output
-                .var_live_at
-                .entry(location)
-                .or_insert_with(Vec::new)
-                .push(var);
+        for &(var, location) in var_live_at.iter() {
+            output.var_live_at.entry(location).or_default().push(var);
         }
     }
 
     region_live_at_rel
         .iter()
-        .map(|&((r, p), _)| (r, p))
+        .map(|&((origin, point), _)| (origin, point))
         .collect()
 }
 
@@ -166,14 +171,14 @@ pub(super) fn make_universal_region_live<T: FactTypes>(
 
     let all_points: BTreeSet<T::Point> = cfg_edge
         .iter()
-        .map(|&(p, _)| p)
-        .chain(cfg_edge.iter().map(|&(_, q)| q))
+        .map(|&(point1, _)| point1)
+        .chain(cfg_edge.iter().map(|&(_, point2)| point2))
         .collect();
 
     region_live_at.reserve(universal_region.len() * all_points.len());
-    for &r in &universal_region {
-        for &p in &all_points {
-            region_live_at.push((r, p));
+    for &origin in &universal_region {
+        for &point in &all_points {
+            region_live_at.push((origin, point));
         }
     }
 }

--- a/polonius-engine/src/output/mod.rs
+++ b/polonius-engine/src/output/mod.rs
@@ -77,7 +77,7 @@ pub struct Output<T: FactTypes> {
     pub subset_anywhere: FxHashMap<T::Origin, BTreeSet<T::Origin>>,
     pub var_live_at: FxHashMap<T::Point, Vec<T::Variable>>,
     pub var_drop_live_at: FxHashMap<T::Point, Vec<T::Variable>>,
-    pub path_maybe_initialized_at: FxHashMap<T::Point, Vec<T::MovePath>>,
+    pub path_maybe_initialized_at: FxHashMap<T::Point, Vec<T::Path>>,
     pub var_maybe_initialized_on_exit: FxHashMap<T::Point, Vec<T::Variable>>,
 }
 

--- a/src/facts.rs
+++ b/src/facts.rs
@@ -38,12 +38,12 @@ index_type!(Origin);
 index_type!(Loan);
 index_type!(Point);
 index_type!(Variable);
-index_type!(MovePath);
+index_type!(Path);
 
 impl FactTypes for LocalFacts {
     type Origin = Origin;
     type Loan = Loan;
     type Point = Point;
     type Variable = Variable;
-    type MovePath = MovePath;
+    type Path = Path;
 }

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -46,7 +46,7 @@ pub(crate) struct InternerTables {
     pub(crate) loans: Interner<Loan>,
     pub(crate) points: Interner<Point>,
     pub(crate) variables: Interner<Variable>,
-    pub(crate) move_paths: Interner<MovePath>,
+    pub(crate) paths: Interner<Path>,
 }
 
 impl InternerTables {
@@ -56,7 +56,7 @@ impl InternerTables {
             loans: Interner::new(),
             points: Interner::new(),
             variables: Interner::new(),
-            move_paths: Interner::new(),
+            paths: Interner::new(),
         }
     }
 }
@@ -79,7 +79,7 @@ intern_impl!(Origin, origins);
 intern_impl!(Loan, loans);
 intern_impl!(Point, points);
 intern_impl!(Variable, variables);
-intern_impl!(MovePath, move_paths);
+intern_impl!(Path, paths);
 
 impl<A, FromA, B, FromB> InternTo<(A, B)> for (FromA, FromB)
 where

--- a/src/test.rs
+++ b/src/test.rs
@@ -136,8 +136,8 @@ fn no_subset_symmetries_exist() -> Result<(), Box<dyn Error>> {
 
     let subset_symmetries_exist = |output: &Output| {
         for (_, subsets) in &output.subset {
-            for (r1, rs) in subsets {
-                if rs.contains(&r1) {
+            for (origin, origins) in subsets {
+                if origins.contains(&origin) {
                     return true;
                 }
             }
@@ -321,7 +321,7 @@ fn smoke_test_success_2() {
 }
 
 #[test]
-// V used in P => V live upon entry into P
+// `var` used in `point` => `var` live upon entry into `point`
 fn var_live_in_single_block() {
     let program = r"
         universal_regions {  }
@@ -345,7 +345,7 @@ fn var_live_in_single_block() {
 }
 
 #[test]
-// P GOTO Q, V used in Q => V live in P
+// `point1` GOTO `point2`, `var` used in `point2` => `var` live in `point1`
 fn var_live_in_successor_propagates_to_predecessor() {
     let program = r"
         universal_regions {  }
@@ -381,7 +381,7 @@ fn var_live_in_successor_propagates_to_predecessor() {
 }
 
 #[test]
-// P GOTO Q, V used in Q, V defined in P => V not live in P
+// `point1` GOTO `point2`, `var` used in `point2`, `var` defined in `point1` => `var` not live in `point1`
 fn var_live_in_successor_killed_by_reassignment() {
     let program = r"
         universal_regions {  }


### PR DESCRIPTION
In which The Great Renaming ™ is basically done:

- continues the `region` to `origin` migration in the rest of `polonius-engine`
- renames `MovePath` to `Path`
- more consistent terminology around `loans` (preferred to `borrows` or `B`s)
- uses words instead of single-letters in comments, datalog rules, datafrog closures, etc basically everywhere, for all Atoms
- minor cleanups here and there