### PR TITLE
easy win: use the fx hasher when interning

### DIFF
--- a/src/intern.rs
+++ b/src/intern.rs
@@ -1,10 +1,11 @@
 use crate::facts::*;
+use rustc_hash::FxHashMap;
 use std::collections::HashMap;
 
 /// When we load facts out of the table, they are essentially random
 /// strings. We create an intern table to map those to small integers.
 pub(crate) struct Interner<TargetType: From<usize> + Copy> {
-    strings: HashMap<String, TargetType>,
+    strings: FxHashMap<String, TargetType>,
     rev_strings: Vec<String>,
 }
 
@@ -14,7 +15,7 @@ where
 {
     fn new() -> Self {
         Self {
-            strings: HashMap::new(),
+            strings: HashMap::default(),
             rev_strings: vec![],
         }
     }


### PR DESCRIPTION
This improves data loading by 13% on `clap` (yes, a whopping 23ms).

(I'm not especially chasing milliseconds in `polonius-bin`, I mostly wanted to remove these interning hot spots from clogging performance profiling results :)