### PR TITLE
Bump versions for the subset errors computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,20 +286,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "polonius"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "pico-args 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "polonius-engine 0.10.0",
- "polonius-parser 0.3.0",
+ "polonius-engine 0.11.0",
+ "polonius-parser 0.4.0",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "polonius-engine"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "datafrog 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "polonius-parser"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "lalrpop 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polonius"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["The Rust Project Developers", "Polonius Developers"]
 description = "Core definition for the Rust borrow checker"
 license = "Apache-2.0/MIT"
@@ -11,11 +11,11 @@ edition = "2018"
 
 [dev-dependencies]
 diff = "0.1.0"
-polonius-parser = {version = "0.3.0", path = "polonius-parser" }
+polonius-parser = {version = "0.4.0", path = "polonius-parser" }
 
 [dependencies]
 rustc-hash = "1.0.0"
-polonius-engine = {version = "0.10.0", path = "polonius-engine" }
+polonius-engine = {version = "0.11.0", path = "polonius-engine" }
 log = "0.4"
 petgraph = "0.4.13"
 pico-args = "0.2"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,12 +1,11 @@
 # polonius
 
-## v????
-
+## v0.6.0
+- update to the latest `polonius-engine`
+- update the test parser to add the new facts related to subset errors
+- update, deduplicate, and remove some dependencies
 - remove `--ignore-region-live-at`, as the `region_live_at` is now gone
   from the inputs and is always calculated!
-
-## v0.6.0
-
 - add a CLI option `--ignore-region-live-at` which ignores those facts and
   recompute them using Polonius even if provided.
 - missing `region_live_at.facts` is no longer an error.
@@ -34,6 +33,15 @@ Add a CLI option `--dump-liveness-graph` to dump a Graphviz file with a
 
 # polonius-engine
 
+## v0.11.0
+
+- adopt a new terminology for the Atoms, and begin documenting everything in a book
+- use a new API to refer to the Atom types via associated types
+- compute new errors: illegal subset relation errors, where for example
+  a `fn foo<'a, 'b>` might require `'a: 'b` annotations to be valid.
+- more work towards supporting initialization facts and errors
+- more work towards defining different phases where each can have its
+  own input facts or produce errors
 
 ## v0.10.0
 

--- a/polonius-engine/Cargo.toml
+++ b/polonius-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polonius-engine"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["The Rust Project Developers", "Polonius Developers"]
 description = "Core definition for the Rust borrow checker"
 license = "Apache-2.0/MIT"

--- a/polonius-parser/Cargo.toml
+++ b/polonius-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polonius-parser"
-version = "0.3.0"
+version = "0.4.0"
 description = "Parser for the Polonius project"
 license = "Apache-2.0/MIT"
 authors = ["The Rust Project Developers"]


### PR DESCRIPTION
This PR updates the versions so that we can update rustc to compute subset errors:
- the test `polonius-parser` crate now supports placeholder loans and known subsets
- the `polonius-engine` crate now supports the new input facts, new output errors, and computes subset errors where some outlives annotations might be required between free regions, for a function to be valid
- the `polonius` crate now supports the new facts for the `./inputs` datasets, and tests these new errors