### PR TITLE
Dump path_maybe_uninitialized_on_exit after compute_move_errors

### DIFF
--- a/polonius-engine/src/output/initialization.rs
+++ b/polonius-engine/src/output/initialization.rs
@@ -214,6 +214,14 @@ fn compute_move_errors<T: FactTypes>(
                 .or_default()
                 .push(path);
         }
+
+        for &(path, location) in path_maybe_uninitialized_on_exit.complete().iter() {
+            output
+                .path_maybe_uninitialized_on_exit
+                .entry(location)
+                .or_default()
+                .push(path);
+        }
     }
 
     InitializationStatus {

--- a/polonius-engine/src/output/mod.rs
+++ b/polonius-engine/src/output/mod.rs
@@ -92,6 +92,7 @@ pub struct Output<T: FactTypes> {
     pub var_live_on_entry: FxHashMap<T::Point, Vec<T::Variable>>,
     pub var_drop_live_on_entry: FxHashMap<T::Point, Vec<T::Variable>>,
     pub path_maybe_initialized_on_exit: FxHashMap<T::Point, Vec<T::Path>>,
+    pub path_maybe_uninitialized_on_exit: FxHashMap<T::Point, Vec<T::Path>>,
     pub known_contains: FxHashMap<T::Origin, BTreeSet<T::Loan>>,
     pub var_maybe_partly_initialized_on_exit: FxHashMap<T::Point, Vec<T::Variable>>,
 }
@@ -412,6 +413,7 @@ impl<T: FactTypes> Output<T> {
             var_live_on_entry: FxHashMap::default(),
             var_drop_live_on_entry: FxHashMap::default(),
             path_maybe_initialized_on_exit: FxHashMap::default(),
+            path_maybe_uninitialized_on_exit: FxHashMap::default(),
             var_maybe_partly_initialized_on_exit: FxHashMap::default(),
             known_contains: FxHashMap::default(),
         }

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -50,6 +50,7 @@ pub(crate) fn dump_output(
             var_live_on_entry,
             var_drop_live_on_entry,
             path_maybe_initialized_on_exit,
+            path_maybe_uninitialized_on_exit,
             var_maybe_partly_initialized_on_exit
         ];
     }


### PR DESCRIPTION
When called with --show-tuples and -v.

This may be useful to debug `move_error`s. If I missed the reason why this shouldn't be dumped, let me know!