### PR TITLE
Prepare release 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "polonius-engine"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "datafrog",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ edition = "2018"
 
 [dev-dependencies]
 diff = "0.1.0"
-polonius-parser = {version = "0.4.0", path = "polonius-parser" }
+polonius-parser = { path = "./polonius-parser" }
 
 [dependencies]
 rustc-hash = "1.0.0"
-polonius-engine = {version = "0.12.0", path = "polonius-engine" }
+polonius-engine = { path = "./polonius-engine" }
 log = "0.4"
 petgraph = "0.4.13"
 pico-args = "0.2"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -36,6 +36,10 @@ Add a CLI option `--dump-liveness-graph` to dump a Graphviz file with a
 
 # polonius-engine
 
+## v.0.13.0
+- compute subset errors in all variants, allows the `Hybrid` variant to be the default again
+- more terminology work, on the relation names, to improve clarity 
+
 ## v.0.12.1
 
 - fix an issue in tracking paths and subpaths in move/init analysis

--- a/polonius-engine/Cargo.toml
+++ b/polonius-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polonius-engine"
-version = "0.12.1"
+version = "0.13.0"
 authors = ["The Rust Project Developers", "Polonius Developers"]
 description = "Core definition for the Rust borrow checker"
 license = "Apache-2.0/MIT"

--- a/polonius-engine/src/output/mod.rs
+++ b/polonius-engine/src/output/mod.rs
@@ -140,8 +140,10 @@ struct Context<'ctx, T: FactTypes> {
     // initialization and liveness, so already computed by the time we get to borrowcking.
     cfg_edge: Relation<(T::Point, T::Point)>,
 
-    // Partial results possibly used by other variants as input
+    // Partial results possibly used by other variants as input. Not currently used yet.
+    #[allow(dead_code)]
     potential_errors: Option<FxHashSet<T::Loan>>,
+    #[allow(dead_code)]
     potential_subset_errors: Option<Relation<(T::Origin, T::Origin)>>,
 }
 


### PR DESCRIPTION
This PR prepares a `polonius-engine` release:
- removes the warnings for the 2 currently unused context sharing fields for the `Hybrid` variant: the potential errors that the `LocationInsensitive` variant computes can (and will, in the future) be used by the `Naive`/`DatafrogOpt` variants to limit their own computation to the loans/subsets that actually matter.
- updates the version to 0.13.0, which includes the results of the more recent round of renaming, and changes to compute subset errors in all variants: this will allow the `Hybrid` variant to be the default once again.